### PR TITLE
Tooltips for buttons

### DIFF
--- a/webextension/src/components/bookmarks-form.js
+++ b/webextension/src/components/bookmarks-form.js
@@ -86,17 +86,21 @@ class BookmarksForm extends Component {
 						className={openAllBtnClasses}
 						type="button"
 						onClick={this.handleOpenAllBookmarks}
-						dangerouslySetInnerHTML={{ __html: AsteriskIcon }}
 						ref={el => { this.refreshBtnEl = el }}
-					/>
+					>
+						<span dangerouslySetInnerHTML={{ __html: AsteriskIcon }}/>
+						<span className="tooltip">Open all in new tab</span>
+					</button>
 
 					<button
 						className={refreshBtnClasses}
 						type="button"
 						onClick={this.handleRefreshBookmarks}
-						dangerouslySetInnerHTML={{ __html: RefreshIcon }}
 						ref={el => { this.refreshBtnEl = el }}
-					/>
+					>
+						<span dangerouslySetInnerHTML={{ __html: RefreshIcon }}/>
+						<span className="tooltip">Fetch bookmarks</span>
+					</button>
 				</form>
 			</header>
 		)

--- a/webextension/src/global-styles/index.css
+++ b/webextension/src/global-styles/index.css
@@ -70,6 +70,25 @@ select {
 	padding: 0;
 }
 
+/* Tooltip for buttons */
+.btn .tooltip {
+	visibility: hidden;
+	position: absolute;
+	right: 28%;
+	width: calc(var(--header-items-size) * 3);
+	border: 1px solid var(--offset-bg);
+	border-radius: var(--border-radius);
+	padding: 3px;
+	background: var(--bg);
+	opacity: 0;
+	transition: opacity .3s;
+}
+
+.btn:hover .tooltip {
+	visibility: visible;
+	opacity: 1;
+}
+
 .u-clearfix::after {
 	content: '';
 	display: table;


### PR DESCRIPTION
Added tooltips for the 'fetch from buku' and 'open in new tab' buttons.
To me the function of these buttons was not really intuitive