### PR TITLE
Optional tag normalization (reproducing tag handling logic used in buku, for compatibility)

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,6 +36,7 @@ nuke:
 webext:
 	${MAKE} prepare
 	yarn && yarn build
+	rm -f '$(RELEASE_DIR)/webext.zip'
 	cd dist && zip -r '../$(RELEASE_DIR)/webext' ./*
 	${MAKE} clean
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint ./src/ --ext ts,tsx",
     "dev": "yarn run prepare && parcel watch ./src/content.html ./src/options.html ./src/backend.ts",
     "build": "yarn run prepare && parcel build ./src/content.html ./src/options.html ./src/backend.ts",
+    "make": "make",
     "test": "jest",
     "fmt": "prettier --write .",
     "fmt-check": "prettier --check ."

--- a/src/components/tag.tsx
+++ b/src/components/tag.tsx
@@ -8,6 +8,7 @@ const TagItem = styled.li<{ removable: boolean }>`
   font-size: 1.3rem;
   font-weight: normal;
   color: ${(props): string => props.theme.textColorOffset};
+  white-space: pre-wrap;
 
   ${(props): FlattenSimpleInterpolation | false =>
     props.removable &&

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -25,10 +25,12 @@ const Page = styled.main`
 
 const OptionsPage: FC = () => {
   const activeTheme = useSelector(state => state.user.activeTheme)
+  const normalizeTags = useSelector(state => state.user.normalizeTags)
   const dispatch = useDispatch()
 
   const [themeOpt, setThemeOpt] = useState(activeTheme)
   const [badgeOpt, setBadgeOpt] = useState(BadgeDisplay.WithCount)
+  const [normTagsOpt, setNormTagsOpt] = useState(normalizeTags)
 
   useEffect(() => {
     getBadgeDisplayOpt().then(res => {
@@ -41,6 +43,10 @@ const OptionsPage: FC = () => {
   useEffect(() => {
     setThemeOpt(activeTheme)
   }, [activeTheme])
+
+  useEffect(() => {
+    setNormTagsOpt(normalizeTags)
+  }, [normalizeTags])
 
   const handleThemeOptChange = (evt: FormEvent<HTMLSelectElement>): void => {
     const themeOpt = evt.currentTarget.value
@@ -56,13 +62,18 @@ const OptionsPage: FC = () => {
     setBadgeOpt(badgeOpt)
   }
 
+  const handleNormTagsOptChange = (evt: FormEvent<HTMLInputElement>): void => {
+    setNormTagsOpt(evt.currentTarget.checked)
+  }
+
   const handleSubmit = (evt: FormEvent<HTMLFormElement>): void => {
     evt.preventDefault()
 
     dispatch(setActiveTheme(themeOpt))
     runTask(sendIsomorphicMessage(IsomorphicMessage.SettingsUpdated))
     runTask(
-      saveSettings({ theme: O.some(themeOpt), badgeDisplay: O.some(badgeOpt) }),
+      saveSettings({ theme: O.some(themeOpt), badgeDisplay: O.some(badgeOpt),
+                     normalizeTags: O.some(normTagsOpt) }),
     )
   }
 
@@ -82,6 +93,12 @@ const OptionsPage: FC = () => {
           <option value={BadgeDisplay.WithoutCount}>Badge without count</option>
           <option value={BadgeDisplay.None}>No badge</option>
         </select>
+        <br />
+        <br />
+        <label title="Split by comma, trim spaces, lowercase, sort, remove duplicates">
+          <input type="checkbox" checked={normTagsOpt} onChange={handleNormTagsOptChange}/>
+          &nbsp;Normalize tags on edit (reproduce buku behaviour)
+        </label>
         <br />
         <br />
         <Button type="submit">Save Settings</Button>

--- a/src/store/epics.ts
+++ b/src/store/epics.ts
@@ -8,13 +8,18 @@ import {
   checkBinaryVersionFromNative,
   HostVersionCheckResult,
 } from "~/modules/comms/native"
-import { getActiveTheme, Theme } from "~/modules/settings"
+import { getActiveTheme, getNormalizeTags, Theme } from "~/modules/settings"
 import { ThunkAC, initAutoStoreSync } from "~/store"
 import {
   setLimitNumRendered,
   setFocusedBookmarkIndex,
 } from "~/store/bookmarks/actions"
-import { setActiveTheme, hostCheckResult, setPage } from "~/store/user/actions"
+import {
+  setActiveTheme,
+  setNormalizeTags,
+  hostCheckResult,
+  setPage,
+} from "~/store/user/actions"
 import { setSearchFilter } from "~/store/input/actions"
 import { addPermanentError } from "~/store/notices/epics"
 import {
@@ -74,6 +79,12 @@ export const onLoad = (): ThunkAC<Promise<void>> => async dispatch => {
     .then(EO.getOrElse(constant<Theme>(Theme.Light)))
     .then(theme => {
       dispatch(setActiveTheme(theme))
+    })
+
+  getNormalizeTags()
+    .then(EO.getOrElse(constant<boolean>(false)))
+    .then(normTags => {
+      dispatch(setNormalizeTags(normTags))
     })
 
   const res = await checkBinaryVersionFromNative()

--- a/src/store/user/actions.ts
+++ b/src/store/user/actions.ts
@@ -10,6 +10,9 @@ export const hostCheckResult = (comms: HostVersionCheckResult) =>
 export const setActiveTheme = (theme: Theme) =>
   action(UserActionTypes.SetActiveTheme, theme)
 
+export const setNormalizeTags = (value: boolean) =>
+  action(UserActionTypes.SetNormalizeTags, value)
+
 export const setDisplayOpenAllBookmarksConfirmation = (display: boolean) =>
   action(UserActionTypes.SetDisplayOpenAllBookmarksConfirmation, display)
 

--- a/src/store/user/reducers.ts
+++ b/src/store/user/reducers.ts
@@ -7,6 +7,7 @@ import {
   Page,
   comms,
   activeTheme,
+  normalizeTags,
   displayOpenAllBookmarksConfirmation,
   page,
 } from "./types"
@@ -19,6 +20,7 @@ export type UserActions = ActionType<typeof userActions>
 const initialState: UserState = {
   comms: HostVersionCheckResult.Unchecked,
   activeTheme: Theme.Light,
+  normalizeTags: false,
   displayOpenAllBookmarksConfirmation: false,
   page: Page.Search,
 }
@@ -31,6 +33,9 @@ const userReducer = curryReducer<UserActions, UserState>(a => _s => {
 
     case UserActionTypes.SetActiveTheme:
       return activeTheme.set(a.payload)
+
+    case UserActionTypes.SetNormalizeTags:
+      return normalizeTags.set(a.payload)
 
     case UserActionTypes.SetDisplayOpenAllBookmarksConfirmation:
       return displayOpenAllBookmarksConfirmation.set(a.payload)

--- a/src/store/user/types.ts
+++ b/src/store/user/types.ts
@@ -7,6 +7,7 @@ export { Theme }
 export interface UserState {
   comms: HostVersionCheckResult
   activeTheme: Theme
+  normalizeTags: boolean
   displayOpenAllBookmarksConfirmation: boolean
   page: Page
 }
@@ -15,6 +16,7 @@ export const userL = Lens.fromProp<AppState>()("user")
 
 export const comms = Lens.fromProp<UserState>()("comms")
 export const activeTheme = Lens.fromProp<UserState>()("activeTheme")
+export const normalizeTags = Lens.fromProp<UserState>()("normalizeTags")
 export const displayOpenAllBookmarksConfirmation = Lens.fromProp<UserState>()(
   "displayOpenAllBookmarksConfirmation",
 )
@@ -25,6 +27,7 @@ export const commsL = userL.compose(comms)
 export enum UserActionTypes {
   HostCheckResult = "HOST_CHECK_RESULT",
   SetActiveTheme = "SET_ACTIVE_THEME",
+  SetNormalizeTags = "SET_NORMALIZE_TAGS",
   SetDisplayOpenAllBookmarksConfirmation = "SET_OPEN_ALL_BOOKMARKS_CONFIRMATION",
   SetPage = "SET_PAGE",
 }


### PR DESCRIPTION
fixes #173:
* adding an extension setting for normalizing tags (disabled by default)
* when enabled, changing the `Tags` input label to `Tags [normalized]` (for clarity)
* when enabled, applying tag handling logic from buku on tag addition/removal (this also covers input validation)

also:
* preserving whitespace when rendering tags
* removing webext archive before making a new one (otherwise it gets bloated on multiple runs due to including _all previous page script versions_)
* allowing to run `make` via `yarn`, i.e. `yarn make webext` (this works from any subfolder without having to navigate into the project root)